### PR TITLE
Update page-landing-page.php

### DIFF
--- a/application/wp-content/themes/navypier/page-landing-page.php
+++ b/application/wp-content/themes/navypier/page-landing-page.php
@@ -150,7 +150,7 @@ if( has_post_thumbnail() ){
 								<div class="info padded">
 									<h3><?php the_title() ?></h3>
 									<p><?php the_excerpt() ?></p>
-									<a href="#" class="icon read-details">Read More</a> 
+									<?php if($post->post_content != "") {?> <a href="#" class="icon read-details">Read More</a> <?php } ?>
 								</div>
 								<div class="options">
 									<a href="#" data-shareid="<?php echo $post->ID;?>" class="icon share">share</a>


### PR DESCRIPTION
Edited to not show the read-more button on entries with empty content (excerpt will house short content, thus having no need for more information)
